### PR TITLE
Update rubocop.yml for EndAlignment and SpaceInsideArrayLiteralBrackets

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -47,7 +47,7 @@ Layout/EmptyLinesAroundModuleBody:
 # assignments, where it should be aligned with the LHS.
 Layout/EndAlignment:
   Enabled: true
-  EnforcedStyleAlignWith: variable
+  EnforcedStyleAlignWith: keyword
   AutoCorrect: true
 
 # Method definitions after `private` or `protected` isolated calls need one
@@ -238,3 +238,6 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   Enabled: true
+
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false


### PR DESCRIPTION
Update EnforcedStyleAlignWith to keep this:
```
test = if true
             'True'
           else
             'False'
           end
```

Update SpaceInsideArrayLiteralBrackets to avoid space after `[` and space before `]`:

`test = [1, 2, 3]`

instead of

`test = [ 1, 2, 3 ]`